### PR TITLE
fix an error using cytotrace2_py

### DIFF
--- a/cytotrace2_python/cytotrace2_py/cytotrace2_py.py
+++ b/cytotrace2_python/cytotrace2_py/cytotrace2_py.py
@@ -161,11 +161,15 @@ def cytotrace2(input_path,
    
     # Process each chunk separately
     results = []
-    with concurrent.futures.ProcessPoolExecutor(max_workers=pred_cores_to_use) as executor:
+    with concurrent.futures.ThreadPoolExecutor(max_workers=pred_cores_to_use) as executor:
         for idx in range(chunk_number):
             chunked_expression = expression.iloc[subsamples[idx], :]
-            print('cytotrace2: Initiated processing batch '+str(idx+1)+'/'+str(chunk_number)+' with '+str(chunked_expression.shape[0])+' cells')
-            results.append(executor.submit(process_subset, idx, chunked_expression, smooth_batch_size, smooth_cores_to_use, species, use_model_dir, output_dir, max_pcs, seed))
+            print('cytotrace2: Initiated processing batch ' + str(idx + 1) + '/' + str(chunk_number) + ' with ' + str(chunked_expression.shape[0]) + ' cells')
+            results.append(executor.submit(process_subset, idx,
+                                        chunked_expression, smooth_batch_size,
+                                        smooth_cores_to_use, species,
+                                        use_model_dir, output_dir, max_pcs, seed))
+        
         for f in concurrent.futures.as_completed(results):
             smooth_by_knn_df = f.result()
             predictions.append(smooth_by_knn_df)


### PR DESCRIPTION
We noticed that when using `concurrent.futures.ProcessPoolExecutor`, the program may raise an error during runtime, so we replaced it with `concurrent.futures.ThreadPoolExecutor`.



```
BrokenProcessPool Traceback (most recent call last)
Cell In[16], line 1
----> 1 results = cytotrace2(adata_control,
2 use_model_dir="../ov/cymodels/5_models_weights",
3 species="human")

File ~/software/rsc/lib/python3.10/site-packages/omicverse/single/_cytotrace2.py:188, in cytotrace2(adata, use_model_dir, species, batch_size, smooth_batch_size, disable_parallelization, max_cores, max_pcs, seed, output_dir)
183 results.append(executor.submit(process_subset, idx,
184 chunked_expression, smooth_batch_size,
185 smooth_cores_to_use, species,
186 use_model_dir, output_dir, max_pcs, seed))
187 for f in concurrent.futures.as_completed(results):
--> 188 smooth_by_knn_df = f.result()
189 predictions.append(smooth_by_knn_df)
191 for idx in range(chunk_number):

File ~/software/rsc/lib/python3.10/concurrent/futures/_base.py:451, in Future.result(self, timeout)
449 raise CancelledError()
450 elif self._state == FINISHED:
--> 451 return self.__get_result()
453 self._condition.wait(timeout)
455 if self._state in [CANCELLED, CANCELLED_AND_NOTIFIED]:

File ~/software/rsc/lib/python3.10/concurrent/futures/_base.py:403, in Future.__get_result(self)
401 if self._exception:
402 try:
--> 403 raise self._exception
404 finally:
405 # Break a reference cycle with the exception in self._exception
406 self = None

BrokenProcessPool: A process in the process pool was terminated abruptly while the future was running or pending
```