### PR TITLE
fix: align delimiter handling with existing behavior (\t default) and improve validation

### DIFF
--- a/cytotrace2_python/cytotrace2_py/common/gen_utils.py
+++ b/cytotrace2_python/cytotrace2_py/common/gen_utils.py
@@ -114,21 +114,19 @@ def build_mapping_dict():
     return mt_dict, mt_dict_alias_and_previous_symbols, mt_mouse_alias_dict, features
 
 
-def load(input_path, sep=','):
+def load(input_path):
     print("cytotrace2: Loading dataset")
-    expression = pd.read_csv(input_path,sep=sep,index_col=0).T # read data
+    expression = pd.read_csv(input_path,sep="\t",index_col=0).T # read data
     # expression = expression.loc[:,~expression.columns.duplicated()].copy() #drop duplicate gene names, to avoid random information loss make sure the genes are unique
     return expression
 
 def read_file(file_path):
     try:
-        file_delim = "," if file_path.lower().endswith(".csv") else "\t"
-    
         if use_dt:
             with warnings.catch_warnings():
                 warnings.simplefilter("ignore", category=pd.errors.ParserWarning)
                 expression = dt.fread(file_path, header=True)
-                colnames = pd.read_csv(file_path, sep=file_delim, nrows=1, index_col=0).columns
+                colnames = pd.read_csv(file_path, sep="\t", nrows=1, index_col=0).columns
                 rownames = expression[:, 0].to_pandas().values.flatten()
                 expression = expression[:, 1:].to_pandas()
                 expression.index = rownames
@@ -137,7 +135,7 @@ def read_file(file_path):
                 expression = expression.transpose()
 
         else:    
-            expression = load(file_path, sep=file_delim)
+            expression = load(file_path)
         
         if expression.columns.duplicated().any():
             raise ValueError("   Please make sure the gene names are unique.")
@@ -151,8 +149,7 @@ def read_file(file_path):
         print("Error encountered while reading input: {}".format(file_path))
         print("Please make sure that you provided the correct path to the input files.",
                 "The following input file formats are supported:",
-                ".csv with comma ',' as delimiter,",
-                "and .txt or .tsv with tab '\\t' as delimiter.")
+                ".csv, .txt, or .tsv with tab '\\t' as delimiter.")
         raise
     
 


### PR DESCRIPTION
## Summary
This PR is an updated submission of #82, addressing the feedback regarding the default delimiter. It retains the structural improvements for input validation while ensuring backward compatibility with the existing `\t` delimiter behavior. 

## Motivation
- In PR #82, the default delimiter was changed, which unintentionally altered the existing behavior. This PR reverts that specific change, keeping `\t` as the default separator to align with existing expectations.
- The structural validations from the previous PR are preserved.

## Changes
- Reverted: Set `\t` back as the default delimiter.
- Preserved: Moved duplicate checks after transpose so that gene and cell uniqueness is validated on the correct axes.
- Preserved: Added early validation for empty inputs (0 cells) to fail fast before downstream processing.

Thank you @pptnz for the previous review!